### PR TITLE
Raise error if Help Scout returns validation errors

### DIFF
--- a/help_scout.gemspec
+++ b/help_scout.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Dennis Paagman", "Miriam Tocino", "Mark Mulder"]
   spec.email         = ["dennispaagman@gmail.com", "miriam.tocino@gmail.com", "markmulder@gmail.com"]
 
-  spec.summary       = "HelpScout is a an api client for Help Scout"
+  spec.summary       = "HelpScout is an API client for Help Scout"
   spec.homepage      = "https://github.com/Springest/help_scout"
   spec.license       = "MIT"
 
@@ -18,11 +18,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "httparty", "~> 0.13"
+  spec.add_runtime_dependency "httparty", "~> 0.14"
 
   spec.add_development_dependency "bundler", "~> 1.12"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "webmock", "~> 2.0"
+  spec.add_development_dependency "rake", "~> 10.5"
+  spec.add_development_dependency "rspec", "~> 3.5"
+  spec.add_development_dependency "webmock", "~> 2.1"
   spec.add_development_dependency "byebug"
 end

--- a/lib/help_scout.rb
+++ b/lib/help_scout.rb
@@ -3,6 +3,7 @@ require "httparty"
 
 class HelpScout
   class ValidationError < StandardError; end
+  class NotImplementedError < StandardError; end
 
   HTTP_CREATED = 201
   HTTP_BAD_REQUEST = 400
@@ -30,6 +31,8 @@ class HelpScout
     elsif last_response.code == HTTP_BAD_REQUEST
       # Validation failed so return the errors
       raise ValidationError, last_response.parsed_response["message"]
+    else
+      raise NotImplementedError, "Help Scout returned something that is not implemented by the help_scout gem yet. Sorry."
     end
   end
 

--- a/lib/help_scout.rb
+++ b/lib/help_scout.rb
@@ -4,6 +4,9 @@ require "httparty"
 class HelpScout
   class ValidationError < StandardError; end
 
+  HTTP_CREATED = 201
+  HTTP_BAD_REQUEST = 400
+
   attr_accessor :last_response
 
   def initialize(api_key)
@@ -20,11 +23,11 @@ class HelpScout
   def create_conversation(data)
     post("conversations", { body: data })
 
-    if last_response.code == 201
+    if last_response.code == HTTP_CREATED
       # Extract ID of created conversation from the Location header
       conversation_uri = last_response.headers["location"]
       return conversation_uri.match(/(\d+)\.json$/)[1]
-    elsif last_response.code == 400
+    elsif last_response.code == HTTP_BAD_REQUEST
       # Validation failed so return the errors
       raise ValidationError, last_response.parsed_response["message"]
     end

--- a/lib/help_scout/version.rb
+++ b/lib/help_scout/version.rb
@@ -1,3 +1,3 @@
 class HelpScout
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/spec/helpscout_spec.rb
+++ b/spec/helpscout_spec.rb
@@ -36,6 +36,20 @@ describe HelpScout do
         expect { client.create_conversation(data) }.to raise_error(HelpScout::ValidationError, "Email is not valid")
       end
     end
+
+    context 'with a not implemented status code' do
+      it 'returns a not implemented error' do
+        data = { subject: "Help me!" }
+
+        url = 'https://api.helpscout.net/v1/conversations.json'
+        stub_request(:post, url).
+          to_return(
+            status: 500,
+          )
+
+        expect { client.create_conversation(data) }.to raise_error(HelpScout::NotImplementedError)
+      end
+    end
   end
 
   describe '#search_conversations' do

--- a/spec/helpscout_spec.rb
+++ b/spec/helpscout_spec.rb
@@ -18,6 +18,24 @@ describe HelpScout do
         )
       expect(client.create_conversation(data)).to eq '123'
     end
+
+    context 'with invalid input' do
+      it 'returns validation errors' do
+        data = { subject: "Help me!", customer: { email: "" } }
+
+        url = 'https://api.helpscout.net/v1/conversations.json'
+        stub_request(:post, url).
+          to_return(
+            status: 400,
+            headers: {
+               'Content-Type' => 'application/json'
+            },
+            body: { error: "Input could not be validated", message: "Email is not valid" }.to_json
+          )
+
+        expect { client.create_conversation(data) }.to raise_error(HelpScout::ValidationError, "Email is not valid")
+      end
+    end
   end
 
   describe '#search_conversations' do


### PR DESCRIPTION
We sometimes send borked data to Help Scout, leading to validation errors on their side. They return these nicely, unfortunately the gem currently assumes success (such an optimist) and gives a non descriptive:
>  "undefined method `match' for nil:NilClass"

Because of a missing `location` header. This adds a check on the status code of the response and raises a `HelpScout::ValidationError` exception with the actual error message returned from HS.