### PR TITLE
Rename modified_since to modifiedSince in get_conversations

### DIFF
--- a/lib/help_scout.rb
+++ b/lib/help_scout.rb
@@ -60,7 +60,7 @@ class HelpScout
   def get_conversations(mailbox_id, page = 1, modified_since = nil)
     options ={
       page: page,
-      modified_since: modified_since,
+      modifiedSince: modified_since,
     }
     get("mailboxes/#{mailbox_id}/conversations", options)
   end


### PR DESCRIPTION
I noticed my `get_conversations` call in Scoutest was fetching seemingly endless amounts of Conversations, even when I specified I only wanted to go back in time like 10 minutes.

You do this specifying via the `modified_since` attribute. But, in Helpscout, it is called `modifiedSince` ([API doc](http://developer.helpscout.net/help-desk-api/conversations/list/) | [screenshot](http://img.springe.st/2016_12_19_11_25_35.png)). Back when I had the helpscout API code in Scoutest, I had already updated this over there, but now it needs to be updated in this gem.