### PR TITLE
Fix broken get_conversations method

### DIFF
--- a/lib/help_scout.rb
+++ b/lib/help_scout.rb
@@ -58,10 +58,13 @@ class HelpScout
   #
   # Returns hash from HS with conversation data
   def get_conversations(mailbox_id, page = 1, modified_since = nil)
-    options ={
-      page: page,
-      modifiedSince: modified_since,
+    options = {
+      query: {
+        page: page,
+        modifiedSince: modified_since,
+      }
     }
+
     get("mailboxes/#{mailbox_id}/conversations", options)
   end
 


### PR DESCRIPTION
The `query` part was missing in `options = {query: {page: page, modifiedSince: modified_since}}`.

Because of this, it was constantly getting _all_ conversations ever, even if I set a specific `modifiedSince`.