### PR TITLE
Add a call to create thread in HelpScout

### DIFF
--- a/lib/help_scout.rb
+++ b/lib/help_scout.rb
@@ -115,6 +115,29 @@ class HelpScout
     get("reports/user/ratings", options)
   end
 
+
+  # Public: Creates conversation thread
+  #
+  # conversion_id - conversation id
+  # thread - thread content to be created
+  # imported - When set to true no outgoing emails or notifications will be
+  #            generated
+  # reload - Set to true to get the entire conversation in the result
+  #
+  # More info: http://developer.helpscout.net/help-desk-api/conversations/create-thread/
+  #
+  # Returns true if created, false otherwise
+  def create_thread(conversation_id:, thread:, imported: nil, reload: nil)
+    query = {}
+    { reload: reload, imported: imported }.each do |key, value|
+      query[key] = value unless value.nil?
+    end
+
+    post("conversations/#{conversation_id}", body: thread, query: query)
+
+    last_response.code == HTTP_CREATED
+  end
+
   protected
 
   def post(path, options = {})

--- a/spec/helpscout_spec.rb
+++ b/spec/helpscout_spec.rb
@@ -88,4 +88,28 @@ describe HelpScout do
       expect(client.search_conversations("tag:conversion")).to eq conversations["items"]
     end
   end
+
+  describe '#create_thread' do
+    let(:thread) do
+      {
+        createdBy: {
+          type: 'user',
+          id: 42,
+        },
+        type: 'note',
+        body: "Hello, I'm a noteworthy!"
+      }
+    end
+
+    it 'does the correct query' do
+      url = 'https://api.helpscout.net/v1/conversations/4242.json'
+      req = stub_request(:post, url).
+        with(body: thread.to_json).
+        to_return(status: 201)
+
+      expect(client.create_thread(conversation_id: 4242, thread: thread)).
+        to eq(true)
+      expect(req).to have_been_requested
+    end
+  end
 end


### PR DESCRIPTION
It's useful to create a note and such. You can admire more info at http://developer.helpscout.net/help-desk-api/conversations/create-thread/