### PR TITLE
Add TooManyRequests error for 429

### DIFF
--- a/lib/help_scout.rb
+++ b/lib/help_scout.rb
@@ -5,6 +5,7 @@ class HelpScout
   class ValidationError < StandardError; end
   class NotImplementedError < StandardError; end
   class NotFoundError < StandardError; end
+  class TooManyRequestsError < StandardError; end
   class InternalServerError < StandardError; end
 
   # Status codes used by Help Scout, not all are implemented in this gem yet.
@@ -14,6 +15,7 @@ class HelpScout
   HTTP_NO_CONTENT = 204
   HTTP_BAD_REQUEST = 400
   HTTP_NOT_FOUND = 404
+  HTTP_TOO_MANY_REQUESTS = 429
   HTTP_INTERNAL_SERVER_ERROR = 500
 
   attr_accessor :last_response
@@ -206,6 +208,8 @@ class HelpScout
       raise NotFoundError
     when HTTP_INTERNAL_SERVER_ERROR
       raise InternalServerError
+    when HTTP_TOO_MANY_REQUESTS
+      raise TooManyRequestsError
     else
       raise NotImplementedError, "Help Scout returned something that is not implemented by the help_scout gem yet: #{@last_response.code}: #{@last_response.parsed_response["message"] if @last_response.parsed_response}"
     end

--- a/lib/help_scout.rb
+++ b/lib/help_scout.rb
@@ -209,7 +209,9 @@ class HelpScout
     when HTTP_INTERNAL_SERVER_ERROR
       raise InternalServerError
     when HTTP_TOO_MANY_REQUESTS
-      raise TooManyRequestsError
+      retry_after = last_response.headers["Retry-After"]
+      error_message = "Rate limit of 200 RPM or 12 POST/PUT/DELETE requests per 5 seconds reached. Next request possible in #{retry_after} seconds."
+      raise TooManyRequestsError, error_message
     else
       raise NotImplementedError, "Help Scout returned something that is not implemented by the help_scout gem yet: #{@last_response.code}: #{@last_response.parsed_response["message"] if @last_response.parsed_response}"
     end

--- a/spec/helpscout_spec.rb
+++ b/spec/helpscout_spec.rb
@@ -144,4 +144,13 @@ describe HelpScout do
       expect(req).to have_been_requested
     end
   end
+
+  describe 'general rate limiting error' do
+    it 'returns TooManyRequestsError' do
+      url = 'https://api.helpscout.net/v1/conversations/1337.json'
+      stub_request(:get, url).to_return(status: 429)
+
+      expect { client.get_conversation(1337) }.to raise_error(HelpScout::TooManyRequestsError)
+    end
+  end
 end

--- a/spec/helpscout_spec.rb
+++ b/spec/helpscout_spec.rb
@@ -148,9 +148,16 @@ describe HelpScout do
   describe 'general rate limiting error' do
     it 'returns TooManyRequestsError' do
       url = 'https://api.helpscout.net/v1/conversations/1337.json'
-      stub_request(:get, url).to_return(status: 429)
+      stub_request(:get, url).
+        to_return(
+          status: 429,
+          headers: {
+            retry_after: '10',
+          }
+        )
 
-      expect { client.get_conversation(1337) }.to raise_error(HelpScout::TooManyRequestsError)
+      error_message = "Rate limit of 200 RPM or 12 POST/PUT/DELETE requests per 5 seconds reached. Next request possible in 10 seconds."
+      expect { client.get_conversation(1337) }.to raise_error(HelpScout::TooManyRequestsError, error_message)
     end
   end
 end


### PR DESCRIPTION
This will make it a bit easier to follow, instead of people having to
remember that 429 is because of rate limiting.

https://httpstatuses.com/429