### PR TITLE
Add update thread method

### DIFF
--- a/lib/help_scout.rb
+++ b/lib/help_scout.rb
@@ -128,7 +128,8 @@ class HelpScout
   #
   # More info: http://developer.helpscout.net/help-desk-api/conversations/create-thread/
   #
-  # Returns true if created, false otherwise
+  # Returns true if created, false otherwise. When used with reload: true it
+  # will return the entire conversation
   def create_thread(conversation_id:, thread:, imported: nil, reload: nil)
     query = {}
     { reload: reload, imported: imported }.each do |key, value|
@@ -137,7 +138,35 @@ class HelpScout
 
     post("conversations/#{conversation_id}", body: thread, query: query)
 
-    last_response.code == HTTP_CREATED
+    if reload
+      last_response.parsed_response
+    else
+      last_response.code == HTTP_CREATED
+    end
+  end
+
+  # Public: Updates conversation thread
+  #
+  # conversion_id - conversation id
+  # thread - thread content to be updated (only the body can be updated)
+  # reload - Set to true to get the entire conversation in the result
+  #
+  # More info: http://developer.helpscout.net/help-desk-api/conversations/update-thread/
+  #
+  # Returns true if updated, false otherwise. When used with reload: true it
+  # will return the entire conversation
+  def update_thread(conversation_id:, thread:, reload: nil)
+    query = {}
+    query[:reload] = reload if reload
+    body = { body: thread[:body] }
+
+    put("conversations/#{conversation_id}/threads/#{thread[:id]}", body: body, query: query)
+
+    if reload
+      last_response.parsed_response
+    else
+      last_response.code == HTTP_OK
+    end
   end
 
   # Public: Update Customer

--- a/spec/helpscout_spec.rb
+++ b/spec/helpscout_spec.rb
@@ -121,13 +121,53 @@ describe HelpScout do
 
     it 'does the correct query' do
       url = 'https://api.helpscout.net/v1/conversations/4242.json'
-      req = stub_request(:post, url).
+      request = stub_request(:post, url).
         with(body: thread.to_json).
         to_return(status: 201)
 
       expect(client.create_thread(conversation_id: 4242, thread: thread)).
         to eq(true)
-      expect(req).to have_been_requested
+      expect(request).to have_been_requested
+    end
+
+    it 'returns response when reload true' do
+      url = 'https://api.helpscout.net/v1/conversations/4242.json?reload=true'
+      request = stub_request(:post, url).
+        with(body: thread.to_json).
+        to_return(status: 201, body: "conversation")
+
+      expect(client.create_thread(conversation_id: 4242, thread: thread, reload: true)).
+        to eq("conversation")
+    end
+  end
+
+  describe '#update_thread' do
+    let(:thread) do
+      {
+        id: 12345,
+        body: "Hello, I'm a noteworthy!"
+      }
+    end
+
+    it 'does the correct query' do
+      url = 'https://api.helpscout.net/v1/conversations/4242/threads/12345.json'
+      request = stub_request(:put, url).
+        with(body: ({ body: thread[:body] }).to_json).
+        to_return(status: 200)
+
+      expect(client.update_thread(conversation_id: 4242, thread: thread)).
+        to eq(true)
+      expect(request).to have_been_requested
+    end
+
+    it 'returns response when reload true' do
+      url = 'https://api.helpscout.net/v1/conversations/4242/threads/12345.json?reload=true'
+      request = stub_request(:put, url).
+        with(body: ({ body: thread[:body] }).to_json).
+        to_return(status: 200, body: "conversation")
+
+      expect(client.update_thread(conversation_id: 4242, thread: thread, reload: true)).
+        to eq("conversation")
     end
   end
 
@@ -136,12 +176,12 @@ describe HelpScout do
 
     it 'does the correct query' do
       url = 'https://api.helpscout.net/v1/customers/1337.json'
-      req = stub_request(:put, url).
+      request = stub_request(:put, url).
         with(body: data.to_json).
         to_return(status: 201)
 
       client.update_customer(1337, data)
-      expect(req).to have_been_requested
+      expect(request).to have_been_requested
     end
   end
 


### PR DESCRIPTION
Adds the [update thread](http://developer.helpscout.net/help-desk-api/conversations/update-thread/) end point.

Also when adding the `reload: true` parameter to `create_thread` and `update_thread` it properly returns the entire conversation instead of a boolean