### PR TITLE
Actual validation errors

### DIFF
--- a/help_scout.gemspec
+++ b/help_scout.gemspec
@@ -6,8 +6,8 @@ require 'help_scout/version'
 Gem::Specification.new do |spec|
   spec.name          = "help_scout"
   spec.version       = HelpScout::VERSION
-  spec.authors       = ["Dennis Paagman", "Miriam Tocino", "Mark Mulder"]
-  spec.email         = ["dennispaagman@gmail.com", "miriam.tocino@gmail.com", "markmulder@gmail.com"]
+  spec.authors       = ["Dennis Paagman", "Miriam Tocino", "Mark Mulder", "Martin Balk"]
+  spec.email         = ["dennispaagman@gmail.com", "miriam.tocino@gmail.com", "markmulder@gmail.com", "m@martinbalk.com"]
 
   spec.summary       = "HelpScout is an API client for Help Scout"
   spec.homepage      = "https://github.com/Springest/help_scout"

--- a/lib/help_scout.rb
+++ b/lib/help_scout.rb
@@ -234,7 +234,7 @@ class HelpScout
     when HTTP_OK, HTTP_CREATED, HTTP_NO_CONTENT
       @last_response.parsed_response
     when HTTP_BAD_REQUEST
-      raise ValidationError, last_response.parsed_response["message"]
+      raise ValidationError, last_response.parsed_response["validationErrors"]
     when HTTP_FORBIDDEN
       raise ForbiddenError
     when HTTP_NOT_FOUND

--- a/spec/helpscout_spec.rb
+++ b/spec/helpscout_spec.rb
@@ -21,7 +21,7 @@ describe HelpScout do
 
     context 'with invalid input' do
       it 'returns validation errors' do
-        data = { subject: "Help me!", customer: { email: "" } }
+        data = { subject: "Help me!", customer: { email: "foo@hotmail.con" } }
 
         url = 'https://api.helpscout.net/v1/conversations.json'
         stub_request(:post, url).
@@ -30,10 +30,19 @@ describe HelpScout do
             headers: {
                'Content-Type' => 'application/json'
             },
-            body: { error: "Input could not be validated", message: "Email is not valid" }.to_json
+            body: {
+              "error" => "Input could not be validated",
+              "validationErrors" => [
+                {
+                  "property" => "customer:email",
+                  "value" => "foo@hotmail.con",
+                  "message" => "Email is not valid"
+                }
+              ]
+            }.to_json
           )
 
-        expect { client.create_conversation(data) }.to raise_error(HelpScout::ValidationError, "Email is not valid")
+        expect { client.create_conversation(data) }.to raise_error(HelpScout::ValidationError, '[{"property"=>"customer:email", "value"=>"foo@hotmail.con", "message"=>"Email is not valid"}]')
       end
     end
 


### PR DESCRIPTION
Found out that the HS API (no longer?) doesn't use the `message` field for validation errors, instead they put data in a field called `validationErrors`. This just puts the whole content of that field in Exception.