### PR TITLE
Add specific error class for 503s

### DIFF
--- a/spec/helpscout_spec.rb
+++ b/spec/helpscout_spec.rb
@@ -84,6 +84,15 @@ describe HelpScout do
       end
     end
 
+    context 'with a 503 status code' do
+      it 'returns ServiceUnavailable' do
+        url = 'https://api.helpscout.net/v1/conversations/1337.json'
+        stub_request(:get, url).to_return(status: 503)
+
+        expect { client.get_conversation(1337) }.to raise_error(HelpScout::ServiceUnavailable)
+      end
+    end
+
     context 'with a not implemented status code' do
       it 'returns a not implemented error' do
         data = { subject: "Help me!" }
@@ -91,7 +100,7 @@ describe HelpScout do
         url = 'https://api.helpscout.net/v1/conversations.json'
         stub_request(:post, url).
           to_return(
-            status: 503,
+            status: 402,
           )
 
         expect { client.create_conversation(data) }.to raise_error(HelpScout::NotImplementedError)


### PR DESCRIPTION
I've also cleaned up the use of `last_response` versus `@last_response`.

The list of errors is growing, now to add one you have to make a class, a constant, and add it to the case statement. Not sure how to improve that as some of them do have some custom logic for some statuses. 

If we have a custom status for 503, it's easier to ignore that specific error in our error logging if wanted. 