### PR TITLE
Expose error details on 500

### DIFF
--- a/lib/help_scout.rb
+++ b/lib/help_scout.rb
@@ -240,7 +240,8 @@ class HelpScout
     when HTTP_NOT_FOUND
       raise NotFoundError
     when HTTP_INTERNAL_SERVER_ERROR
-      raise InternalServerError
+      error_message = JSON.parse(last_response.body)["error"]
+      raise InternalServerError, error_message
     when HTTP_TOO_MANY_REQUESTS
       retry_after = last_response.headers["Retry-After"]
       error_message = "Rate limit of 200 RPM or 12 POST/PUT/DELETE requests per 5 seconds reached. Next request possible in #{retry_after} seconds."

--- a/spec/helpscout_spec.rb
+++ b/spec/helpscout_spec.rb
@@ -65,11 +65,22 @@ describe HelpScout do
     end
 
     context 'with a 500 status code' do
-      it 'returns InternalServerError' do
-        url = 'https://api.helpscout.net/v1/conversations/1337.json'
-        stub_request(:get, url).to_return(status: 500)
+      it 'returns InternalServerError with body' do
+        expected_error_message = "Did not find any valid email for customer 1111"
 
-        expect { client.get_conversation(1337) }.to raise_error(HelpScout::InternalServerError)
+        url = 'https://api.helpscout.net/v1/conversations/1337.json'
+        stub_request(:post, url).
+          to_return(
+            status: 500,
+            body: {
+              "code": 500,
+              "error": expected_error_message,
+            }.to_json,
+        )
+
+        expect {
+          client.create_thread(conversation_id: 1337, thread: {})
+        }.to raise_error(HelpScout::InternalServerError, expected_error_message)
       end
     end
 


### PR DESCRIPTION
Found this out while reproducing a 500:

```
(byebug) JSON.parse(last_response.body)
{"code"=>500, "error"=>"Did not find any valid email for customer [snipped]"}
```

This will help us debug potential 500 errors :) 