### PR TITLE
Omit Content-Type header when request has no body

### DIFF
--- a/lib/help_scout.rb
+++ b/lib/help_scout.rb
@@ -238,10 +238,12 @@ class HelpScout
       basic_auth: {
         username: @api_key, password: 'X'
       },
-      headers: {
-        'Content-Type' => 'application/json'
-      }
+      headers: {}
     }.merge(options)
+
+    if options.key?(:body)
+      options[:headers]['Content-Type'] ||= 'application/json'
+    end
 
     @last_response = HTTParty.send(method, uri, options)
     case last_response.code

--- a/lib/help_scout/version.rb
+++ b/lib/help_scout/version.rb
@@ -1,3 +1,3 @@
 class HelpScout
-  VERSION = "0.12.0"
+  VERSION = "0.12.1"
 end

--- a/spec/helpscout_spec.rb
+++ b/spec/helpscout_spec.rb
@@ -249,4 +249,22 @@ describe HelpScout do
       expect { client.get_conversation(1337) }.to raise_error(HelpScout::TooManyRequestsError, error_message)
     end
   end
+
+  it "sends Content-Type when body" do
+      url = "https://api.helpscout.net/v1/conversations/4242.json"
+      stub_request(:delete, url).to_return(status: 200)
+      stub_request(:put, url).to_return(status: 200)
+
+      client.delete_conversation(4242)
+      expect(WebMock).to have_requested(:delete, url).with(headers: {
+        "Authorization": "Basic YXBpX2tleTpY"
+      })
+
+      client.update_conversation(4242, subject: "Hello World")
+      expect(WebMock).to have_requested(:put, url).with(headers: {
+        "Authorization": "Basic YXBpX2tleTpY",
+        "Content-Type": "application/json"
+      })
+
+  end
 end


### PR DESCRIPTION
Helpscout tries to parse the body when a `Content-Type` header is submitted,
it now checks if the request got a body, if so set the `Content-Type` header to 
`application/json` unless `Content-Type` header is already set.